### PR TITLE
createJavaScriptNode --> createScriptProcessor

### DIFF
--- a/audio.js
+++ b/audio.js
@@ -44,7 +44,7 @@ function AudioPlayer(generator, opts) {
 		var channelCount = 2;
 		var bufferSize = 4096*4; // Higher for less gitches, lower for less latency
 		
-		var node = context.createJavaScriptNode(bufferSize, 0, channelCount);
+		var node = context.createScriptProcessor(bufferSize, 0, channelCount);
 		
 		node.onaudioprocess = function(e) { process(e) };
 


### PR DESCRIPTION
I was not getting any audio due to

  TypeError: context.createJavaScriptNode is not a function, audio.js:47

in Firefox 28/29 and Chrome 31. Apparently createJavaScriptNode has been renamed to createScriptProcessor[1].  Making this change fixed things for me in Firefox and Chrome.

[1] https://developer.mozilla.org/en-US/docs/Web/API/AudioContext.createJavaScriptNode
