### PR TITLE
Update midifile.js

### DIFF
--- a/midifile.js
+++ b/midifile.js
@@ -77,6 +77,7 @@ function MidiFile(data) {
 							+ (stream.readInt8() << 8)
 							+ stream.readInt8()
 						)
+						if (event.microsecondsPerBeat == 0) throw "Expected number of seconds per beat is > 0. Beat length calculation depends on this value.";
 						return event;
 					case 0x54:
 						event.subtype = 'smpteOffset';


### PR DESCRIPTION
Throw parse error when the tempo parsing does not generate a valid microsecondsPerBeat value.

See issue #15 and mudcube/MIDI.js#134