### PR TITLE
Update link to fork

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 THIS PROJECT IS NO LONGER MAINTAINED. http://unmaintained.tech/
 ===============================================================
 
-see jasmid.ts fork: https://github.com/pravdomil/jasmid.ts
+see jasmid.ts fork: https://github.com/@sightread/jasmid.ts
 
 
 jasmid - A Javascript MIDI file reader and synthesiser


### PR DESCRIPTION
Hi @gasman,

First off, thank you for making `jasmid`!
I know this package is unmaintained, so I don't have any expectation of a quick (or any!) response here.

The current link to the jasmid fork at [pravdomil/jasmid.ts](https://github.com/pravdomil/jasmid.ts) 404s. I believe @pravdomil must have deleted the repo.

I've created a fork of the fork at [@sightread/jasmid.ts](https://github.com/sightread/jasmid.ts) and this PR updates the link to point there instead. Happy to maintain it as well.

Thanks!